### PR TITLE
TASK: Rename `identifier` to `name`

### DIFF
--- a/Migrations/ContentRepository/Version20230501011400.yaml
+++ b/Migrations/ContentRepository/Version20230501011400.yaml
@@ -1,0 +1,18 @@
+up:
+  comments: 'Raname identifier field to name'
+  migration:
+    - filters:
+        - type: 'NodeType'
+          settings:
+            nodeType: 'Sitegeist.PaperTiger:Mixin.Name'
+        - type: 'PropertyNotEmpty'
+          settings:
+            propertyName: "identifier"
+      transformations:
+        - type: 'RenameProperty'
+          settings:
+            oldPropertyName: 'identifier'
+            newPropertyName: 'name'
+
+down:
+  comments: 'No down migration available'

--- a/NodeTypes/Field/Button/Button.fusion
+++ b/NodeTypes/Field/Button/Button.fusion
@@ -1,11 +1,11 @@
 prototype(Sitegeist.PaperTiger:Field.Button) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('name')}
   value = ${q(node).property('value')}
   label = ${q(node).property('label')}
 
   renderer = afx`
       <Neos.Fusion.Form:FieldContainer
-        field.name={props.identifier}
+        field.name={props.name}
       >
         <Neos.Fusion.Form:Button field.value={props.value} >{props.label}</Neos.Fusion.Form:Button>
       </Neos.Fusion.Form:FieldContainer>

--- a/NodeTypes/Field/Button/Button.yaml
+++ b/NodeTypes/Field/Button/Button.yaml
@@ -12,6 +12,6 @@ Sitegeist.PaperTiger:Field.Button:
       type: string
       ui:
         label: 'Value'
-        showInCreationDialog: true
+        showInCreationDialog: false
         inspector:
           group: form

--- a/NodeTypes/Field/CheckBoxes/CheckBoxes.fusion
+++ b/NodeTypes/Field/CheckBoxes/CheckBoxes.fusion
@@ -1,12 +1,12 @@
 prototype(Sitegeist.PaperTiger:Field.CheckBoxes) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('name')}
   label = ${q(node).property('label')}
   isRequired = ${q(node).property('isRequired')}
   options = ${q(node).property('options')}
 
   renderer = afx`
     <Sitegeist.PaperTiger:FieldContainer
-      field.name={props.identifier}
+      field.name={props.name}
       field.multiple={true}
       label={props.label}
     >

--- a/NodeTypes/Field/Date/Date.fusion
+++ b/NodeTypes/Field/Date/Date.fusion
@@ -1,5 +1,5 @@
 prototype(Sitegeist.PaperTiger:Field.Date) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('name')}
   label = ${q(node).property('label')}
   placeholder = ${q(node).property('placeholder')}
   isRequired = ${q(node).property('isRequired')}
@@ -8,7 +8,7 @@ prototype(Sitegeist.PaperTiger:Field.Date) < prototype(Neos.Neos:ContentComponen
 
   renderer = afx`
     <Sitegeist.PaperTiger:FieldContainer
-        field.name={props.identifier}
+        field.name={props.name}
         label={props.label}
     >
       <Neos.Fusion.Form:Date

--- a/NodeTypes/Field/Dropdown/Dropdown.fusion
+++ b/NodeTypes/Field/Dropdown/Dropdown.fusion
@@ -1,5 +1,5 @@
 prototype(Sitegeist.PaperTiger:Field.Dropdown) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('name')}
   label = ${q(node).property('label')}
   isRequired = ${q(node).property('isRequired')}
   isMultiple = ${q(node).property('isMultiple')}
@@ -10,7 +10,7 @@ prototype(Sitegeist.PaperTiger:Field.Dropdown) < prototype(Neos.Neos:ContentComp
 
   renderer = afx`
     <Sitegeist.PaperTiger:FieldContainer
-      field.name={props.identifier}
+      field.name={props.name}
       field.multiple={props.isMultiple}
       label={props.label}
     >

--- a/NodeTypes/Field/Email/Email.fusion
+++ b/NodeTypes/Field/Email/Email.fusion
@@ -1,12 +1,12 @@
 prototype(Sitegeist.PaperTiger:Field.Email) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('name')}
   label = ${q(node).property('label')}
   placeholder = ${q(node).property('placeholder')}
   isRequired = ${q(node).property('isRequired')}
 
   renderer = afx`
     <Sitegeist.PaperTiger:FieldContainer
-        field.name={props.identifier}
+        field.name={props.name}
         label={props.label}
     >
       <Neos.Fusion.Form:Input

--- a/NodeTypes/Field/Field.yaml
+++ b/NodeTypes/Field/Field.yaml
@@ -4,6 +4,7 @@ Sitegeist.PaperTiger:Field:
   superTypes:
     'Neos.Neos:Content': true
     'Sitegeist.PaperTiger:Field.Constraint': true
+    'Sitegeist.PaperTiger:Mixin.Name': true
   ui:
     inspector:
       groups:
@@ -19,21 +20,3 @@ Sitegeist.PaperTiger:Field:
           label: "Error message"
           position: 30
           icon: 'icon-exclamation-triangle'
-  properties:
-    identifier:
-      type: string
-      ui:
-        label: "Identifier / Name"
-        showInCreationDialog: true
-        reloadIfChanged: true
-        help:
-          message: "A technical identifier for the field. Must only contain number and chars."
-        inspector:
-          group: form
-      validation:
-        'Neos.Neos/Validation/NotEmptyValidator': []
-        'Neos.Neos/Validation/StringLengthValidator':
-          minimum: 1
-          maximum: 255
-        'Neos.Neos/Validation/RegularExpressionValidator':
-          regularExpression: '/^[a-z0-9\-]+$/i'

--- a/NodeTypes/Field/FriendlyCaptcha/FriendlyCaptcha.fusion
+++ b/NodeTypes/Field/FriendlyCaptcha/FriendlyCaptcha.fusion
@@ -1,14 +1,14 @@
 prototype(Sitegeist.PaperTiger:Field.FriendlyCaptcha) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('_identifier')}
 
   renderer = Neos.Fusion:Case {
     backend {
       condition = ${node.context.inBackend}
       renderer = afx`
         <Sitegeist.PaperTiger:FieldContainer
-          field.name={props.identifier}
+          field.name={props.name}
         >
-          <label>FriendlyCaptcha</label> {props.identifier}
+          <label>FriendlyCaptcha</label>
         </Sitegeist.PaperTiger:FieldContainer>
       `
     }
@@ -18,7 +18,7 @@ prototype(Sitegeist.PaperTiger:Field.FriendlyCaptcha) < prototype(Neos.Neos:Cont
       renderer = afx`
         <Sitegeist.FusionForm.FriendlyCaptcha:Scripts />
         <Sitegeist.PaperTiger:FieldContainer
-          field.name={props.identifier}
+          field.name={props.name}
         >
           <Sitegeist.FusionForm.FriendlyCaptcha:Captcha />
         </Sitegeist.PaperTiger:FieldContainer>

--- a/NodeTypes/Field/FriendlyCaptcha/FriendlyCaptcha.yaml
+++ b/NodeTypes/Field/FriendlyCaptcha/FriendlyCaptcha.yaml
@@ -5,3 +5,4 @@ Sitegeist.PaperTiger:Field.FriendlyCaptcha:
     group: form.special
   superTypes:
     'Sitegeist.PaperTiger:Field': true
+    'Sitegeist.PaperTiger:Mixin.Name': false

--- a/NodeTypes/Field/Hidden/Hidden.fusion
+++ b/NodeTypes/Field/Hidden/Hidden.fusion
@@ -1,5 +1,5 @@
 prototype(Sitegeist.PaperTiger:Field.Hidden) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('name')}
   value = ${q(node).property('value')}
 
   renderer = Neos.Fusion:Case {
@@ -7,9 +7,9 @@ prototype(Sitegeist.PaperTiger:Field.Hidden) < prototype(Neos.Neos:ContentCompon
       condition = ${node.context.inBackend}
       renderer = afx`
         <Sitegeist.PaperTiger:FieldContainer
-          field.name={props.identifier}
+          field.name={props.name}
         >
-          <label>Hidden</label> {props.identifier}:{props.value}
+          <label>Hidden</label> {props.name}:{props.value}
         </Sitegeist.PaperTiger:FieldContainer>
       `
     }
@@ -18,7 +18,7 @@ prototype(Sitegeist.PaperTiger:Field.Hidden) < prototype(Neos.Neos:ContentCompon
       condition = true
       renderer = afx`
         <Neos.Fusion.Form:FieldContainer
-          field.name={props.identifier}
+          field.name={props.name}
           attributes.style="display:none; !important"
           attributes.autocomplete="off"
           attributes.tabindex="-1"

--- a/NodeTypes/Field/Honeypot/Honeypot.fusion
+++ b/NodeTypes/Field/Honeypot/Honeypot.fusion
@@ -1,14 +1,14 @@
 prototype(Sitegeist.PaperTiger:Field.Honeypot) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('_identifier')}
 
   renderer = Neos.Fusion:Case {
     backend {
       condition = ${node.context.inBackend}
       renderer = afx`
         <Sitegeist.PaperTiger:FieldContainer
-          field.name={props.identifier}
+          field.name={props.name}
         >
-          <label>Honeypot</label> {props.identifier}
+          <label>Honeypot</label>
         </Sitegeist.PaperTiger:FieldContainer>
       `
     }
@@ -17,7 +17,7 @@ prototype(Sitegeist.PaperTiger:Field.Honeypot) < prototype(Neos.Neos:ContentComp
       condition = true
       renderer = afx`
         <Neos.Fusion.Form:FieldContainer
-          field.name={props.identifier}
+          field.name={props.name}
           attributes.style="display:none !important;"
           attributes.autocomplete="off"
           attributes.tabindex="-1"

--- a/NodeTypes/Field/Honeypot/Honeypot.yaml
+++ b/NodeTypes/Field/Honeypot/Honeypot.yaml
@@ -5,3 +5,4 @@ Sitegeist.PaperTiger:Field.Honeypot:
     group: form.special
   superTypes:
     'Sitegeist.PaperTiger:Field': true
+    'Sitegeist.PaperTiger:Mixin.Name': false

--- a/NodeTypes/Field/Number/Number.fusion
+++ b/NodeTypes/Field/Number/Number.fusion
@@ -1,5 +1,5 @@
 prototype(Sitegeist.PaperTiger:Field.Number) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('name')}
   label = ${q(node).property('label')}
   placeholder = ${q(node).property('placeholder')}
   isRequired = ${q(node).property('isRequired')}
@@ -8,7 +8,7 @@ prototype(Sitegeist.PaperTiger:Field.Number) < prototype(Neos.Neos:ContentCompon
 
   renderer = afx`
     <Sitegeist.PaperTiger:FieldContainer
-        field.name={props.identifier}
+        field.name={props.name}
         label={props.label}
     >
       <Neos.Fusion.Form:Input

--- a/NodeTypes/Field/RadioButtons/RadioButtons.fusion
+++ b/NodeTypes/Field/RadioButtons/RadioButtons.fusion
@@ -1,12 +1,12 @@
 prototype(Sitegeist.PaperTiger:Field.RadioButtons) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('name')}
   label = ${q(node).property('label')}
   isRequired = ${q(node).property('isRequired')}
   options = ${q(node).property('options')}
 
   renderer = afx`
     <Sitegeist.PaperTiger:FieldContainer
-      field.name={props.identifier}
+      field.name={props.name}
       label={props.label}
     >
       <Neos.Fusion:Loop items={props.options} itemName="option">

--- a/NodeTypes/Field/Slider/Slider.fusion
+++ b/NodeTypes/Field/Slider/Slider.fusion
@@ -1,5 +1,5 @@
 prototype(Sitegeist.PaperTiger:Field.Slider) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('name')}
   label = ${q(node).property('label')}
   placeholder = ${q(node).property('placeholder')}
   isRequired = ${q(node).property('isRequired')}
@@ -9,7 +9,7 @@ prototype(Sitegeist.PaperTiger:Field.Slider) < prototype(Neos.Neos:ContentCompon
 
   renderer = afx`
     <Sitegeist.PaperTiger:FieldContainer
-        field.name={props.identifier}
+        field.name={props.name}
         label={props.label}
     >
       <Neos.Fusion.Form:Input

--- a/NodeTypes/Field/TelephoneNumber/TelephoneNumber.fusion
+++ b/NodeTypes/Field/TelephoneNumber/TelephoneNumber.fusion
@@ -1,12 +1,12 @@
 prototype(Sitegeist.PaperTiger:Field.TelephoneNumber) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('name')}
   label = ${q(node).property('label')}
   placeholder = ${q(node).property('placeholder')}
   isRequired = ${q(node).property('isRequired')}
 
   renderer = afx`
     <Sitegeist.PaperTiger:FieldContainer
-        field.name={props.identifier}
+        field.name={props.name}
         label={props.label}
     >
       <Neos.Fusion.Form:Input

--- a/NodeTypes/Field/Text/MultiLine/MultiLine.fusion
+++ b/NodeTypes/Field/Text/MultiLine/MultiLine.fusion
@@ -1,5 +1,5 @@
 prototype(Sitegeist.PaperTiger:Field.Text.MultiLine) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('name')}
   label = ${q(node).property('label')}
   placeholder = ${q(node).property('placeholder')}
   isRequired = ${q(node).property('isRequired')}
@@ -10,7 +10,7 @@ prototype(Sitegeist.PaperTiger:Field.Text.MultiLine) < prototype(Neos.Neos:Conte
 
   renderer = afx`
     <Sitegeist.PaperTiger:FieldContainer
-      field.name={props.identifier}
+      field.name={props.name}
       label={props.label}
     >
       <Neos.Fusion.Form:Textarea

--- a/NodeTypes/Field/Text/SingleLine/SingleLine.fusion
+++ b/NodeTypes/Field/Text/SingleLine/SingleLine.fusion
@@ -1,5 +1,5 @@
 prototype(Sitegeist.PaperTiger:Field.Text.SingleLine) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('name')}
   label = ${q(node).property('label')}
   placeholder = ${q(node).property('placeholder')}
   isRequired = ${q(node).property('isRequired')}
@@ -9,7 +9,7 @@ prototype(Sitegeist.PaperTiger:Field.Text.SingleLine) < prototype(Neos.Neos:Cont
 
   renderer = afx`
     <Sitegeist.PaperTiger:FieldContainer
-      field.name={props.identifier}
+      field.name={props.name}
       label={props.label}
     >
       <Neos.Fusion.Form:Input

--- a/NodeTypes/Field/Upload/Upload.fusion
+++ b/NodeTypes/Field/Upload/Upload.fusion
@@ -1,5 +1,5 @@
 prototype(Sitegeist.PaperTiger:Field.Upload) < prototype(Neos.Neos:ContentComponent) {
-  identifier = ${q(node).property('identifier')}
+  name = ${q(node).property('name')}
   label = ${q(node).property('label')}
   isMultiple = ${q(node).property('isMultiple')}
   isRequired = ${q(node).property('isRequired')}
@@ -7,7 +7,7 @@ prototype(Sitegeist.PaperTiger:Field.Upload) < prototype(Neos.Neos:ContentCompon
 
   renderer = afx`
     <Sitegeist.PaperTiger:FieldContainer
-      field.name={props.identifier}
+      field.name={props.name}
       field.multiple={props.isMultiple}
       label={props.label}
     >

--- a/NodeTypes/Mixin/Name.yaml
+++ b/NodeTypes/Mixin/Name.yaml
@@ -1,0 +1,20 @@
+Sitegeist.PaperTiger:Mixin.Name:
+  abstract: true
+  properties:
+    name:
+      type: string
+      ui:
+        label: "Name"
+        help:
+          message: "A technical identifier for the field. Must only contain number and chars."
+        reloadIfChanged: false
+        showInCreationDialog: true
+        inspector:
+          group: form
+      validation:
+        'Neos.Neos/Validation/NotEmptyValidator': []
+        'Neos.Neos/Validation/StringLengthValidator':
+          minimum: 1
+          maximum: 255
+        'Neos.Neos/Validation/RegularExpressionValidator':
+          regularExpression: '/^[a-z0-9\-]+$/i'

--- a/Resources/Private/Fusion/Prototypes/FieldCollection.Schema.fusion
+++ b/Resources/Private/Fusion/Prototypes/FieldCollection.Schema.fusion
@@ -7,14 +7,14 @@ prototype(Sitegeist.PaperTiger:FieldCollection.Schema) < prototype(Neos.Fusion:C
       itemName = 'node'
       carryName = 'carry'
       itemReducer = Neos.Fusion:Value {
-          identifier =  ${q(node).property('identifier')}
+          name =  ${q(node).is('[instanceof Sitegeist.PaperTiger:Mixin.Name]') ? q(node).property('name') : q(node).property('_identifier')}
           schema = Neos.Fusion:Renderer {
             @if.canRender = Neos.Fusion:CanRender {
               type = ${node.nodeType.name + '.Schema'}
             }
             type = ${node.nodeType.name + '.Schema'}
           }
-          value = ${(this.identifier && this.schema) ? Array.set(carry, this.identifier, this.schema) : carry}
+          value = ${(this.name && this.schema) ? Array.set(carry, this.name, this.schema) : carry}
       }
       initialValue = ${{}}
     }


### PR DESCRIPTION
The field `identifier` was renamed to `name` and is removed from captcha and honeypot fields.

The following migration will adjust existing content for you
```
 ./flow node:migrate 20230501011400
```