### PR TITLE
BUGFIX: support uppercase characters in DataTemplate fieldNames

### DIFF
--- a/Classes/FusionObjects/DataTemplateImplementation.php
+++ b/Classes/FusionObjects/DataTemplateImplementation.php
@@ -28,7 +28,7 @@ class DataTemplateImplementation extends AbstractFusionObject
         $data = $this->getData();
 
         return preg_replace_callback(
-            '/{([a-z0-9\\.]+)}/um',
+            '/{([A-Za-z0-9\\.]+)}/um',
             function(array $matches) use ($data) {
                 $value = Arrays::getValueByPath($data, $matches[1]);
                 return (is_string($value) || $value instanceof \Stringable) ? htmlspecialchars(strip_tags((string) $value)) : '';


### PR DESCRIPTION
Without this change fieldnames with uppercase identifiers were not replaced in the data template.