### PR TITLE
BUGFIX: Add visual distinction between actions in the backend

### DIFF
--- a/NodeTypes/Action/Email/Email.Preview.fusion
+++ b/NodeTypes/Action/Email/Email.Preview.fusion
@@ -30,7 +30,7 @@ prototype(Sitegeist.PaperTiger:Action.Email.Preview) < prototype(Neos.Fusion:Com
 
   renderer = afx`
     <p @if.hasMissingFields={private.requiredFields}>
-      The following information is missing: {Array.join(private.requiredFields, ', ')}
+        <strong style="color:red">The following configuration is missing: {Array.join(private.requiredFields, ', ')}</strong>
     </p>
     <dl>
       <dt>Subject</dt>

--- a/Resources/Private/Fusion/Prototypes/ActionCollection.Preview.fusion
+++ b/Resources/Private/Fusion/Prototypes/ActionCollection.Preview.fusion
@@ -17,9 +17,12 @@ prototype(Sitegeist.PaperTiger:ActionCollection.Preview.ContentCase) < prototype
   }
 
   renderer = afx`
-    <dl>
-      <dt>{props.label}</dt>
-      <dd>{props.preview}</dd>
-    </dl>
+    <div style="margin:20px 0">
+      <div><strong>{props.label}</strong></div>
+      <Neos.Fusion:Fragment @if={props.preview}>
+        <hr />
+        <div>{props.preview}</div>
+      </Neos.Fusion:Fragment>
+    </div>
   `
 }


### PR DESCRIPTION
otherwise editors could not understand the configured actions