### PR TITLE
FEATURE: Show fieldnames with curly braces in the backend for copy pasting to action configuration

### DIFF
--- a/NodeTypes/Form.fusion
+++ b/NodeTypes/Form.fusion
@@ -46,6 +46,7 @@ prototype(Sitegeist.PaperTiger:Form) < prototype(Neos.Neos:ContentComponent) {
                             style="display: inline-block; background-color: black; color:white; border-radius: 50%; text-align: center; width: 2em; height: 2em;">2</span>
                         <span style="color: black; font-size: 1.5em; position:relative; top: .1em; ">&nbsp;&nbsp;   Follow up actions</span>
                     </div>
+                    <Sitegeist.PaperTiger:ActionCollection.Fieldnames nodePath="fields"/>
                     <Sitegeist.PaperTiger:ActionCollection.Preview nodePath="actions"/>
                 </div>
             `

--- a/Resources/Private/Fusion/Prototypes/ActionCollection.Fieldnames.fusion
+++ b/Resources/Private/Fusion/Prototypes/ActionCollection.Fieldnames.fusion
@@ -1,11 +1,15 @@
 prototype(Sitegeist.PaperTiger:ActionCollection.Fieldnames) < prototype(Neos.Fusion:Component) {
     nodePath = null
-    renderer = afx`
-        <div>
-            Fieldnames:&nbsp;
-            <Neos.Fusion:Loop @glue=", " items={q(node).children(props.nodePath).find('[instanceof Sitegeist.PaperTiger:Field]').get()} itemName="field">
-                {'{' + q(field).property("name") + '}'}
-            </Neos.Fusion:Loop>
-        </div>
-    `
+    describtion = 'Fieldnames:&nbsp;'
+    renderer = Neos.Fusion:Tag {
+        content = Neos.Fusion:Join {
+            describtion = ${props.describtion}
+            fieldNames = Neos.Fusion:Loop {
+                @glue = ', '
+                items = ${q(node).children(props.nodePath).find('[instanceof Sitegeist.PaperTiger:Field]').get()}
+                itemName = 'field'
+                itemRenderer = ${'{' + q(field).property('name') + '}'}
+            }
+        }
+    }
 }

--- a/Resources/Private/Fusion/Prototypes/ActionCollection.Fieldnames.fusion
+++ b/Resources/Private/Fusion/Prototypes/ActionCollection.Fieldnames.fusion
@@ -1,0 +1,11 @@
+prototype(Sitegeist.PaperTiger:ActionCollection.Fieldnames) < prototype(Neos.Fusion:Component) {
+    nodePath = null
+    renderer = afx`
+        <div>
+            Fieldnames:&nbsp;
+            <Neos.Fusion:Loop @glue=", " items={q(node).children(props.nodePath).find('[instanceof Sitegeist.PaperTiger:Field]').get()} itemName="field">
+                {'{' + q(field).property("name") + '}'}
+            </Neos.Fusion:Loop>
+        </div>
+    `
+}


### PR DESCRIPTION
A simple approach first.  A better one may follow but this should already help.

Resolves: #13