### PR TITLE
BUGIX: Allow min and max value 0

### DIFF
--- a/NodeTypes/Field/Number/Number.fusion
+++ b/NodeTypes/Field/Number/Number.fusion
@@ -15,10 +15,11 @@ prototype(Sitegeist.PaperTiger:Field.Number) < prototype(Neos.Neos:ContentCompon
         >
             <Neos.Fusion.Form:Input
                 attributes.type="number"
+                attributes.inputmode="numeric"
                 attributes.required={props.isRequired}
                 attributes.placeholder={props.placeholder || false}
-                attributes.min={props.minimumValue ? props.minimumValue : false}
-                attributes.max={props.minimumValue ? props.maximumValue : false}
+                attributes.min={Type.isNumeric(props.minimumValue) ? props.minimumValue : false}
+                attributes.max={Type.isNumeric(props.maximumValue) ? props.maximumValue : false}
                 attributes.oninvalid={"this.setCustomValidity('" + props.customErrorMessage + "')"}
                 attributes.oninvalid.@if={props.customErrorMessageEnabled}
                 attributes.oninput={"this.setCustomValidity('')"}


### PR DESCRIPTION
Fix #31 

Add also the attribute `inputmode="numeric"`, which enables the numeric keyboard on non-keyboard devices such as devices with an touchscreen keyboard