### PR TITLE
FEATURE: allow email headers to be set via variable

### DIFF
--- a/NodeTypes/Action/Email/Email.Definition.fusion
+++ b/NodeTypes/Action/Email/Email.Definition.fusion
@@ -9,12 +9,19 @@ prototype(Sitegeist.PaperTiger:Action.Email.Definition) < prototype(Neos.Fusion:
     html.@if.isHtmlOrMultipart = ${this.format != 'plaintext'}
     html.@process.asTemplate = Sitegeist.PaperTiger:Action.DataTemplate
     recipientAddress = ${q(node).property('recipientAddress')}
+    recipientAddress.@process.asTemplate = Sitegeist.PaperTiger:Action.DataTemplate
     recipientName = ${q(node).property('recipientName')}
+    recipientName.@process.asTemplate = Sitegeist.PaperTiger:Action.DataTemplate
     senderAddress = ${q(node).property('senderAddress')}
+    senderAddress.@process.asTemplate = Sitegeist.PaperTiger:Action.DataTemplate
     senderName = ${q(node).property('senderName')}
+    senderName.@process.asTemplate = Sitegeist.PaperTiger:Action.DataTemplate
     replyToAddress = ${q(node).property('replyToAddress')}
+    replyToAddress.@process.asTemplate = Sitegeist.PaperTiger:Action.DataTemplate
     carbonCopyAddress = ${q(node).property('carbonCopyAddress')}
+    carbonCopyAddress.@process.asTemplate = Sitegeist.PaperTiger:Action.DataTemplate
     blindCarbonCopyAddress = ${q(node).property('blindCarbonCopyAddress')}
+    blindCarbonCopyAddress.@process.asTemplate = Sitegeist.PaperTiger:Action.DataTemplate
     attachUploads = ${q(node).property('attachUploads')}
     testMode = ${q(node).property('testMode')}
 

--- a/NodeTypes/Action/Email/Email.Definition.fusion
+++ b/NodeTypes/Action/Email/Email.Definition.fusion
@@ -9,11 +9,8 @@ prototype(Sitegeist.PaperTiger:Action.Email.Definition) < prototype(Neos.Fusion:
     html.@if.isHtmlOrMultipart = ${this.format != 'plaintext'}
     html.@process.asTemplate = Sitegeist.PaperTiger:Action.DataTemplate
     recipientAddress = ${q(node).property('recipientAddress')}
-    recipientAddress.@process.asTemplate = Sitegeist.PaperTiger:Action.DataTemplate
     recipientName = ${q(node).property('recipientName')}
-    recipientName.@process.asTemplate = Sitegeist.PaperTiger:Action.DataTemplate
     senderAddress = ${q(node).property('senderAddress')}
-    senderAddress.@process.asTemplate = Sitegeist.PaperTiger:Action.DataTemplate
     senderName = ${q(node).property('senderName')}
     senderName.@process.asTemplate = Sitegeist.PaperTiger:Action.DataTemplate
     replyToAddress = ${q(node).property('replyToAddress')}


### PR DESCRIPTION
We have built a contact form for a customer.
The reply-to address should correspond to the address that the website user entered as their own in the form.

Unfortunately, we encountered a problem:
```
Email "{email}" does not comply with addr-spec of RFC 2822.
```

With this pull request, I have built in that you can also set the e-mail headers such as: Reply address, sender address, recipient address etc. via variable