### PR TITLE
Update README for SymfonyMailer usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ The actions are configured in the inspector and show a preview in the backend.
 - `Sitegeist.PaperTiger:Action.Message` - Show a specified `message` while replacing `{identifier}` with submitted data.
 - `Sitegeist.PaperTiger:Action.Redirct` - Redirect the user to the specified Document afer submit.
 - `Sitegeist.PaperTiger:Action.Email` - Email action
-  using [Sitegeist.Neos.SymfonyMailer](https://github.com/sitegeist/Sitegeist.Neos.SymfonyMailer) 
+  using [Sitegeist.Neos.SymfonyMailer](https://github.com/sitegeist/Sitegeist.Neos.SymfonyMailer) ([see config below](#disable-symfonymailer))
   The properties `subject`, `text` and `html` will replace `{identifier}` with submitted data. Submitted files can be
-  added as attachments. ([see config below](#disable-symfonymailer))
+  added as attachments. 
 
 !!! During submission some properties will replace parts `{identifier}` with submitted data by applying the
 processor `Sitegeist.PaperTiger:Action.DataTemplate`. !!!

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ processor `Sitegeist.PaperTiger:Action.DataTemplate`. !!!
 
 ### Disable SymfonyMailer
 
-If Swiftmailer doesn't work, change the configuration in your `settings.yaml` to disable the SymfonyMailer and use the default Neos `dsn`:
+If SymfonyMailer doesn't work, change the configuration in your `settings.yaml` to disable it and use the default Neos `dsn`:
 
 ```yaml
 Sitegeist:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The actions are configured in the inspector and show a preview in the backend.
 - `Sitegeist.PaperTiger:Action.Message` - Show a specified `message` while replacing `{identifier}` with submitted data.
 - `Sitegeist.PaperTiger:Action.Redirct` - Redirect the user to the specified Document afer submit.
 - `Sitegeist.PaperTiger:Action.Email` - Email action
-  using [Sitegeist.Neos.SymfonyMailer](https://github.com/sitegeist/Sitegeist.Neos.SymfonyMailer) ([see config below](#disable-symfonymailer))
+  using [Sitegeist.Neos.SymfonyMailer](https://github.com/sitegeist/Sitegeist.Neos.SymfonyMailer) ([see config below](#disable-symfonymailer))  
   The properties `subject`, `text` and `html` will replace `{identifier}` with submitted data. Submitted files can be
   added as attachments. 
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ The actions are configured in the inspector and show a preview in the backend.
 - `Sitegeist.PaperTiger:Action.Message` - Show a specified `message` while replacing `{identifier}` with submitted data.
 - `Sitegeist.PaperTiger:Action.Redirct` - Redirect the user to the specified Document afer submit.
 - `Sitegeist.PaperTiger:Action.Email` - Email action
-  using [Sitegeist.Neos.SymfonyMailer](https://github.com/sitegeist/Sitegeist.Neos.SymfonyMailer)  
+  using [Sitegeist.Neos.SymfonyMailer](https://github.com/sitegeist/Sitegeist.Neos.SymfonyMailer) 
   The properties `subject`, `text` and `html` will replace `{identifier}` with submitted data. Submitted files can be
-  added as attachments.
+  added as attachments. ([see config below](swiftmailer))
 
 !!! During submission some properties will replace parts `{identifier}` with submitted data by applying the
 processor `Sitegeist.PaperTiger:Action.DataTemplate`. !!!
@@ -88,6 +88,17 @@ processor `Sitegeist.PaperTiger:Action.DataTemplate`. !!!
 <img src="./Documentation/Screenshots/ActionNodeTypes.png" width="920" />
 
 ## Configuration
+
+### Disable SymfonyMailer
+
+If Swiftmailer doesn't work, change the configuration in your `settings.yaml` to disable the SymfonyMailer and use the default Neos `dsn`:
+
+```yaml
+Sitegeist:
+    Neos:
+        SymfonyMailer:
+        dsn: 'native://default'
+```
 
 ### Custom field NodeTypes
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The actions are configured in the inspector and show a preview in the backend.
 - `Sitegeist.PaperTiger:Action.Email` - Email action
   using [Sitegeist.Neos.SymfonyMailer](https://github.com/sitegeist/Sitegeist.Neos.SymfonyMailer) 
   The properties `subject`, `text` and `html` will replace `{identifier}` with submitted data. Submitted files can be
-  added as attachments. ([see config below](swiftmailer))
+  added as attachments. ([see config below](#disable-symfonymailer))
 
 !!! During submission some properties will replace parts `{identifier}` with submitted data by applying the
 processor `Sitegeist.PaperTiger:Action.DataTemplate`. !!!


### PR DESCRIPTION
We had a problem with the SymfonyMailer where E-Mails were not sent due to a “sendmail -bs” error.  To fix the issue, we needed to read through the SymfonyMailer README. We had to disable the SymfonyMailer dsn and use the default from Neos. This information is also related to PaperTiger, so it makes sense to mention it here as well.