### PR TITLE
TASK: Add notice for Symfony Mailer configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The actions are configured in the inspector and show a preview in the backend.
 - `Sitegeist.PaperTiger:Action.Message` - Show a specified `message` while replacing `{identifier}` with submitted data.
 - `Sitegeist.PaperTiger:Action.Redirct` - Redirect the user to the specified Document afer submit.
 - `Sitegeist.PaperTiger:Action.Email` - Email action
-  using [Sitegeist.Neos.SymfonyMailer](https://github.com/sitegeist/Sitegeist.Neos.SymfonyMailer)  
+  using [Sitegeist.Neos.SymfonyMailer](https://github.com/sitegeist/Sitegeist.Neos.SymfonyMailer)
   The properties `subject`, `text` and `html` will replace `{identifier}` with submitted data. Submitted files can be
   added as attachments.
 
@@ -88,6 +88,17 @@ processor `Sitegeist.PaperTiger:Action.DataTemplate`. !!!
 <img src="./Documentation/Screenshots/ActionNodeTypes.png" width="920" />
 
 ## Configuration
+
+### Symfony Mailer
+
+Don't forget to configure the Symfony Mailer `dsn`. Here is an example:
+
+```yaml
+Sitegeist:
+  Neos:
+    SymfonyMailer:
+      dsn: 'native://default'
+```
 
 ### Custom field NodeTypes
 


### PR DESCRIPTION
While using PaperTiger we noticed that we had to configure SymfonyMailer separately from the NeosMailer in order for mails to be sent.

I think it's important to mention this information in the README, for other people who stumble across this problem. 

If you have feedback regarding my PR, be free to write comments.
