### PR TITLE
Update link to native NEOS SymfonyMailer in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The actions are configured in the inspector and show a preview in the backend.
 - `Sitegeist.PaperTiger:Action.Message` - Show a specified `message` while replacing `{identifier}` with submitted data.
 - `Sitegeist.PaperTiger:Action.Redirct` - Redirect the user to the specified Document afer submit.
 - `Sitegeist.PaperTiger:Action.Email` - Email action
-  using [Sitegeist.Neos.SymfonyMailer](https://github.com/sitegeist/Sitegeist.Neos.SymfonyMailer)
+  using [Neos.SymfonyMailer](https://github.com/neos/symfonymailer).
   The properties `subject`, `text` and `html` will replace `{identifier}` with submitted data. Submitted files can be
   added as attachments.
 


### PR DESCRIPTION
Sitegeist.PaperTiger:Action.Email seems to work with the default Neos.SymfonyMailer nowadays. Also, requiring sitegeist/neos-symfonymailer in conjunction with sitegeist/papertiger doesn't seem to work with composer.